### PR TITLE
Fixes validation error on referrals model

### DIFF
--- a/lib/server/routes/referrals.js
+++ b/lib/server/routes/referrals.js
@@ -47,7 +47,7 @@ ReferralsRouter.prototype.sendReferralEmail = function(req, res) {
         return new Promise((resolve, reject) => {
           self._isNotCurrentUser(email)
             .then(() => self._sendEmail(userId, email, marketing))
-            .then(() => Referral.create(marketing, email, 'email'))
+            .then(() => self._createReferral(marketing, email))
             .then((referral) => {
               console.log('referral', referral)
               return resolve({
@@ -114,6 +114,16 @@ ReferralsRouter.prototype._sendEmail = function(senderEmail, recipientEmail, mar
       }
       return resolve(true);
     });
+  });
+};
+
+ReferralsRouter.prototype._createReferral = function(marketing, email) {
+  const { Referral } = this.models;
+  return new Promise((resolve, reject) => {
+    marketing._id = marketing.id;
+    Referral.create(marketing, email, 'email')
+      .then((referral) => resolve(referral))
+      .catch((err) => reject(err));
   });
 };
 


### PR DESCRIPTION
Was occurring because it was looking for `marketing._id`, which is removed from the front end. Add a quick little conversion to add that field back in so we don't have to redo `service-storage-models` stuff. 

Didn't catch this because of the order of operations where this would never work because the mailer always failed. 