### PR TITLE
Fix signup route

### DIFF
--- a/lib/server/routes/credits.js
+++ b/lib/server/routes/credits.js
@@ -11,6 +11,7 @@ const { CREDIT_TYPES, PROMO_CODE, STRIPE, PROMO_EXPIRES, PROMO_AMOUNT } = requir
 const paymentProcessorAdapters = require('storj-service-storage-models/lib/models/payment-processor-adapters');
 const stripe = require('../vendor/stripe');
 const errors = require('storj-service-error-types');
+const Promise = require('bluebird');
 
 // TODO: Refactor all stripe-related endpoints into a single endpoint
 // to remain payment processor agnostic.
@@ -31,23 +32,37 @@ inherits(CreditsRouter, Router);
 
 CreditsRouter.prototype.handleReferralSignup = function(req, res) {
   const self = this;
-  const Marketing = this.models.Marketing;
+  const Marketing = self.models.Marketing;
 
-  Marketing.isValidReferralLink(req.body.referralLink)
-    .then((marketing) => {
-      self._issueSignupCredit(req.body, 'referral')
-        .then((credit) => {
-          self._convertReferralRecipient(credit, marketing, req.body)
-            .then((referral) => res.status(200).send(referral))
-            .catch((err) => res.status(500).send(err));
-        })
-        .catch((err) => {
-          if (err.message === 'Invalid referral link') {
-            return self._issueSignupCredit(req.body)
-          }
-        })
-    })
-}
+  console.log('HIT: handleReferralSignup', req.body);
+
+  Marketing.isValidReferralLink(req.body.referralLink).then((marketing) => {
+      console.log('VALID MARKETING DOC: ', marketing)
+      marketing._id = marketing.id;
+    self._getReferral(req.body, marketing)
+      .then((referral) => {
+        self._issueReferralSignupCredit(req.body, referral)
+          .then((credit) => self._convertReferralRecipient(referral, credit))
+          .then((referral) => res.status(200).send(referral))
+          .catch((err) => res.status(500).send(err));
+      })
+      .catch((err) => res.status(500).send(err))
+  })
+  .catch((err) => {
+    if (err.message === 'Invalid referral link') {
+      return self.handleRegularSignup(req, res);
+    }
+    res.status(500).send(err);
+  });
+};
+
+CreditsRouter.prototype.handleRegularSignup = function(req, res) {
+  console.log('handlRegularSignup hit');
+  const self = this;
+  self._issueRegularSignupCredit(req.body)
+    .then((credit) => res.status(200).send(credit))
+    .catch((err) => res.status(500).send(err));
+};
 
 CreditsRouter.prototype.handleSignups = function (req, res) {
   console.log('handlingSignup: ', req.body);
@@ -64,27 +79,40 @@ CreditsRouter.prototype.handleSignups = function (req, res) {
       return self.handleReferralSignup(req, res);
     }
 
-    self._issueSignupCredit(req.body)
-      .then((credit) => res.status(200).send(credit))
-      .catch((err) => res.status(500).send(err));
+    return self.handleRegularSignup(req, res);
   })
 }
 
-/**
- * anonymous function - description
- *
- * @param  {type} credit    description
- * @param  {type} marketing refers to sender marketing document, NOT recipient
- * @param  {type} data      description
- * @return {type}           description
- */
-CreditsRouter.prototype._convertReferralRecipient = function (credit, marketing, data) {
-  console.log('_convertReferralRecipient: ', credit,
-    'Marketing: ', marketing,
-    'Link: ', data.referralLink, data.email);
 
+CreditsRouter.prototype._issueRegularSignupCredit = function(data) {
+  console.log('_issueRegularSignupCredit data:', data)
+  const Credit = this.models.Credit;
+
+  return new Promise((resolve, reject) => {
+    const newCredit = new Credit({
+      user: data.email,
+      type: CREDIT_TYPES.AUTO,
+      promo_code: PROMO_CODE.NEW_SIGNUP,
+      promo_amount: PROMO_AMOUNT.NEW_SIGNUP,
+      promo_expires: PROMO_EXPIRES.NEW_SIGNUP
+    });
+
+    newCredit
+      .save()
+      .then((credit) => {
+        console.log('Regular new user credit created');
+        return resolve(credit);
+      })
+      .catch((err) => {
+        console.log('Error with creating regular sign up credit', err);
+        return reject(err);
+      });
+  });
+};
+
+CreditsRouter.prototype._getReferral = function(data, marketing) {
   const Referral = this.models.Referral;
-
+  console.log('data', data, 'marketing' , marketing)
   return new Promise((resolve, reject) => {
     Referral
       .findOne({
@@ -94,46 +122,94 @@ CreditsRouter.prototype._convertReferralRecipient = function (credit, marketing,
       .then((referral) => {
         console.log('REFERRAL', referral);
         if (referral) {
-          console.log('MODIFYING REFERRAL; ', referral);
-          return resolve(referral.convert_recipient_signup(credit));
+          console.log('GOT EXISTING REFERRAL; ', referral);
+          return resolve(referral);
         }
-        console.log('creating new referral:', referral);
+        console.log('creating new referral:');
         Referral
           .create(marketing, data.email, 'link')
-          .then((referral) => referral.convert_recipient_signup(credit))
-          .then((referral) => resolve(referral))
+          .then((referral) => {
+            console.log('referral', referral)
+            return resolve(referral)
+          })
+          .catch((err) => reject(errors.InternalError(err)));
       })
       .catch((err) => reject(errors.InternalError(err)))
   });
-}
+};
 
-CreditsRouter.prototype._issueSignupCredit = function (data, userType) {
-  console.log('_issueSignupCredit, data, userType: ', data, userType);
-
+CreditsRouter.prototype._issueReferralSignupCredit = function(data, referral) {
   const Credit = this.models.Credit;
-  const type = userType === 'referral' ? 'REFERRAL_RECIPIENT' : 'NEW_SIGNUP';
+
   return new Promise((resolve, reject) => {
+    console.log('_issueReferralSignupCredit', data, referral.id);
+
     const newCredit = new Credit({
       user: data.email,
       type: CREDIT_TYPES.AUTO,
-      promo_code: PROMO_CODE[type],
-      promo_amount: PROMO_AMOUNT[type],
-      promo_expires: PROMO_EXPIRES[type]
+      promo_code: PROMO_CODE.REFERRAL_RECIPIENT,
+      promo_amount: PROMO_AMOUNT.REFERRAL_RECIPIENT,
+      promo_expires: PROMO_EXPIRES.REFERRAL_RECIPIENT,
+      promo_referral_id: referral.id
     });
 
-    console.log('issueSignupCredit Created: ', newCredit);
-    newCredit
-      .save()
-      .then((credit) => {
-        console.log('issueSignupCredit credit created: ', credit);
-        return resolve(credit)
-      })
-      .catch((err) => {
-        console.log('Error _issueSignupCredit: ', err);
-        return reject(err)
-      });
+    newCredit.save().then((credit) => {
+      console.log('CREDIT SAVED');
+      return resolve(credit);
+    })
+    .catch((err) => {
+      console.log('ERROR _issueReferralSignupCredit', err);
+      return reject(err);
+    });
   });
 };
+
+// CreditsRouter.prototype._issueReferralSignUpCredit = function(data, referral) {
+  // console.log('_issueReferralSignupCredit', data, referral)
+  // const Credit = this.models.Credit;
+  // return new Promise((resolve, reject) => {
+  //   const newCredit = new Credit({
+  //     user: data.email,
+  //     type: CREDIT_TYPES.AUTO,
+  //     promo_code: PROMO_CODE.REFERRAL_RECIPIENT,
+  //     promo_amount: PROMO_AMOUNT.REFERRAL_RECIPIENT,
+  //     promo_expires: PROMO_EXPIRES.REFERRAL_RECIPIENT,
+  //     promo_referral_id: referral.id
+  //   });
+
+  //   console.log('_issueReferralSignupCredit', newCredit);
+
+  //   newCredit.save().then((credit) => {
+  //     console.log('_issueReferralSignupCredit credit created', credit);
+  //     return resolve(credit);
+  //   })
+  //   .catch((err) => {
+  //     console.log('Error _issueRegularSignupCredit', err);
+  //     return reject(err);
+  //   });
+  // });
+// };
+
+/**
+ * anonymous function - description
+ *
+ * @param  {type} credit    description
+ * @param  {type} marketing refers to sender marketing document, NOT recipient
+ * @param  {type} data      description
+ * @return {type}           description
+ */
+CreditsRouter.prototype._convertReferralRecipient = function(referral, credit) {
+
+  console.log('_convertReferralRecipient')
+
+  const Referral = this.models.Referral;
+
+  return new Promise((resolve, reject) => {
+    referral.convert_recipient_signup(credit)
+      .then((referral) => resolve(referral))
+      .catch((err) => reject(errors.InternalError(err)));
+  });
+}
 
 function getBalance(credits, debits) {
   const sumCredits = (total, item) => {

--- a/lib/server/routes/credits.js
+++ b/lib/server/routes/credits.js
@@ -164,32 +164,6 @@ CreditsRouter.prototype._issueReferralSignupCredit = function(data, referral) {
   });
 };
 
-// CreditsRouter.prototype._issueReferralSignUpCredit = function(data, referral) {
-  // console.log('_issueReferralSignupCredit', data, referral)
-  // const Credit = this.models.Credit;
-  // return new Promise((resolve, reject) => {
-  //   const newCredit = new Credit({
-  //     user: data.email,
-  //     type: CREDIT_TYPES.AUTO,
-  //     promo_code: PROMO_CODE.REFERRAL_RECIPIENT,
-  //     promo_amount: PROMO_AMOUNT.REFERRAL_RECIPIENT,
-  //     promo_expires: PROMO_EXPIRES.REFERRAL_RECIPIENT,
-  //     promo_referral_id: referral.id
-  //   });
-
-  //   console.log('_issueReferralSignupCredit', newCredit);
-
-  //   newCredit.save().then((credit) => {
-  //     console.log('_issueReferralSignupCredit credit created', credit);
-  //     return resolve(credit);
-  //   })
-  //   .catch((err) => {
-  //     console.log('Error _issueRegularSignupCredit', err);
-  //     return reject(err);
-  //   });
-  // });
-// };
-
 /**
  * anonymous function - description
  *


### PR DESCRIPTION
Modularize handling signs up more. Applies `promo_referral_id` for new credits generated via referrals (Credit creation requires a `promo_referral_id` which is used in `generate-referral-credits`). 

Add in additional `console.logs` until this is deemed stable.