### PR TITLE
Remove matching on `isFreeTier` for debit generation

### DIFF
--- a/lib/queries/generate-debits.js
+++ b/lib/queries/generate-debits.js
@@ -69,9 +69,6 @@ const calculateUserAmountOwedForStorage = function(billingPeriodStart, billingPe
               },
               {
                 "fileRenewalTime": {$gte: billingPeriodStartIsoDate}
-              },
-              {
-                "user.isFreeTier": {$eq: false}
               }
             ]
           }
@@ -211,11 +208,6 @@ const calculateUserAmountOwedForBandwidth = function(billingPeriodStart, billing
         {
           $unwind: {
             path: "$user"
-          }
-        },
-        {
-          $match: {
-            "user.isFreeTier": {$eq: false}
           }
         },
         {


### PR DESCRIPTION
Step 1 of 2 implementing new paid/free threshold logic