### PR TITLE
Remove new-signup credit for users + documentation

### DIFF
--- a/lib/server/routes/credits.js
+++ b/lib/server/routes/credits.js
@@ -7,7 +7,12 @@ const middleware = require('storj-service-middleware');
 const rawbody = middleware.rawbody;
 const log = require('../../logger');
 const authenticate = middleware.authenticate;
-const { CREDIT_TYPES, PROMO_CODE, PROMO_EXPIRES, PROMO_AMOUNT } = require('storj-service-storage-models/lib/constants');
+const {
+  CREDIT_TYPES,
+  PROMO_CODE,
+  PROMO_EXPIRES,
+  PROMO_AMOUNT
+} = require('storj-service-storage-models/lib/constants');
 const stripe = require('../vendor/stripe');
 const errors = require('storj-service-error-types');
 const Promise = require('bluebird');
@@ -34,41 +39,6 @@ function CreditsRouter(options) {
 
 inherits(CreditsRouter, Router);
 
-
-CreditsRouter.prototype.handleReferralSignup = function(req, res) {
-  const self = this;
-  const Marketing = self.models.Marketing;
-
-  console.log('HIT: handleReferralSignup', req.body);
-
-  Marketing.isValidReferralLink(req.body.referralLink).then((marketing) => {
-      console.log('VALID MARKETING DOC: ', marketing)
-      marketing._id = marketing.id;
-    self._getReferral(req.body, marketing)
-      .then((referral) => {
-        self._issueReferralSignupCredit(req.body, referral)
-          .then((credit) => self._convertReferralRecipient(referral, credit))
-          .then((referral) => res.status(200).send(referral))
-          .catch((err) => res.status(500).send(err));
-      })
-      .catch((err) => res.status(500).send(err))
-  })
-  .catch((err) => {
-    if (err.message === 'Invalid referral link') {
-      return self.handleRegularSignup(req, res);
-    }
-    res.status(500).send(err);
-  });
-};
-
-CreditsRouter.prototype.handleRegularSignup = function(req, res) {
-  console.log('HIT: handleRegularSignup for', req.body);
-  const self = this;
-  self._issueRegularSignupCredit(req.body)
-    .then((credit) => res.status(200).send(credit))
-    .catch((err) => res.status(500).send(err));
-};
-
 CreditsRouter.prototype.handleSignups = function (req, res) {
   console.log('handlingSignup: ', req.body);
 
@@ -84,34 +54,35 @@ CreditsRouter.prototype.handleSignups = function (req, res) {
       return self.handleReferralSignup(req, res);
     }
 
-    return self.handleRegularSignup(req, res);
+    return res.status(200).send('Success');
   })
 }
 
+CreditsRouter.prototype.handleReferralSignup = function(req, res) {
+  const self = this;
+  const Marketing = self.models.Marketing;
 
-CreditsRouter.prototype._issueRegularSignupCredit = function(data) {
-  console.log('_issueRegularSignupCredit data:', data)
-  const Credit = this.models.Credit;
+  console.log('HIT: handleReferralSignup', req.body);
 
-  return new Promise((resolve, reject) => {
-    const newCredit = new Credit({
-      user: data.email,
-      type: CREDIT_TYPES.AUTO,
-      promo_code: PROMO_CODE.NEW_SIGNUP,
-      promo_amount: PROMO_AMOUNT.NEW_SIGNUP,
-      promo_expires: PROMO_EXPIRES.NEW_SIGNUP
-    });
-
-    newCredit
-      .save()
-      .then((credit) => {
-        console.log('REGULAR USER CREDIT CREATED:', credit);
-        return resolve(credit);
-      })
-      .catch((err) => {
-        console.log('Error with creating regular sign up credit', err);
-        return reject(err);
-      });
+  Marketing.isValidReferralLink(req.body.referralLink).then((marketing) => {
+    console.log('VALID MARKETING DOC: ', marketing)
+    marketing._id = marketing.id;
+    self._getReferral(req.body, marketing).then((referral) => {
+      self._issueReferralSignupCredit(req.body, referral)
+        .then((credit) => self._convertReferralRecipient(referral, credit))
+        // TODO: Send back amount of credit created so user knows it worked
+        // res.status(200).send({ creditAmount: credit.promo_amount,
+        // referralLink: referral.link })
+        .then((referral) => res.status(200).send('Success'))
+        .catch((err) => res.status(500).send(err));
+    })
+    .catch((err) => res.status(500).send(err))
+  })
+  .catch((err) => {
+    if (err.message === 'Invalid referral link') {
+      return self.handleRegularSignup(req, res);
+    }
+    return res.status(500).send(err);
   });
 };
 

--- a/lib/server/routes/credits.js
+++ b/lib/server/routes/credits.js
@@ -55,7 +55,7 @@ CreditsRouter.prototype.handleSignups = function (req, res) {
       console.log('Error creating signup marketing: ', err);
       return res.status(500).send(err);
     }
-
+    console.log('CREATED MARKETING DOC: ', marketing);
     if (req.body.referralLink) {
       return self.handleReferralSignup(req, res);
     }

--- a/lib/server/routes/credits.js
+++ b/lib/server/routes/credits.js
@@ -39,6 +39,12 @@ function CreditsRouter(options) {
 
 inherits(CreditsRouter, Router);
 
+/**
+ * Creates marketing document and generates referral credit if user has been
+ * referred
+ * @param {string} req.body.email - new user's email
+ * @param {string} req.body.referralLink - optional. link from location.query
+ */
 CreditsRouter.prototype.handleSignups = function (req, res) {
   console.log('handlingSignup: ', req.body);
 
@@ -58,6 +64,12 @@ CreditsRouter.prototype.handleSignups = function (req, res) {
   })
 }
 
+/**
+ * Handles sign ups with referral links. Validates referral link, issues
+ * sign up credit, and tracks that the referral recipient has been converted
+ * @param {string} req.body.email - new user's email
+ * @param {string} req.body.referralLink - referral link from location.query
+ */
 CreditsRouter.prototype.handleReferralSignup = function(req, res) {
   const self = this;
   const Marketing = self.models.Marketing;
@@ -86,6 +98,15 @@ CreditsRouter.prototype.handleReferralSignup = function(req, res) {
   });
 };
 
+/**
+ * Used by `handleReferralSignup` to retrieve the referral doc related to the
+ * referral link passed in. If the referral doc exists, then the referral type
+ * has been previously generated and is of type 'email' (meaning some user sent
+ * an email to this new user previously). If the referral doc does not exist,
+ * then no referral email was sent prior to sign up, and type is of 'link'
+ * @param {Object} data - req.body containing email and referralLink
+ * @param {Object} marketing - marketing document belong to referral sender
+ */
 CreditsRouter.prototype._getReferral = function(data, marketing) {
   const Referral = this.models.Referral;
   console.log('data', data, 'marketing', marketing)
@@ -113,6 +134,11 @@ CreditsRouter.prototype._getReferral = function(data, marketing) {
   });
 };
 
+/**
+ * Issues a referral recipient sign up credit
+ * @param {Object} data - req.body with email and referralLink props
+ * @param {Object} referral - referral doc
+ */
 CreditsRouter.prototype._issueReferralSignupCredit = function(data, referral) {
   const Credit = this.models.Credit;
 
@@ -140,17 +166,13 @@ CreditsRouter.prototype._issueReferralSignupCredit = function(data, referral) {
 };
 
 /**
- * anonymous function - description
+ * Dates when a referral recipient was converted.
  *
- * @param  {type} credit    description
- * @param  {type} marketing refers to sender marketing document, NOT recipient
- * @param  {type} data      description
- * @return {type}           description
+ * @param {object} referral - instance of referral doc
+ * @param {object} credit - referral recipient credit doc
  */
 CreditsRouter.prototype._convertReferralRecipient = function(referral, credit) {
-
   console.log('_convertReferralRecipient')
-  const Referral = this.models.Referral;
 
   return new Promise((resolve, reject) => {
     referral.convert_recipient_signup(credit)

--- a/lib/server/routes/credits.js
+++ b/lib/server/routes/credits.js
@@ -7,7 +7,12 @@ const middleware = require('storj-service-middleware');
 const rawbody = middleware.rawbody;
 const log = require('../../logger');
 const authenticate = middleware.authenticate;
-const { CREDIT_TYPES, PROMO_CODE, PROMO_EXPIRES, PROMO_AMOUNT } = require('storj-service-storage-models/lib/constants');
+const {
+  CREDIT_TYPES,
+  PROMO_CODE,
+  PROMO_EXPIRES,
+  PROMO_AMOUNT
+} = require('storj-service-storage-models/lib/constants');
 const stripe = require('../vendor/stripe');
 const errors = require('storj-service-error-types');
 const Promise = require('bluebird');
@@ -46,10 +51,20 @@ CreditsRouter.prototype.handleReferralSignup = function(req, res) {
       marketing._id = marketing.id;
     self._getReferral(req.body, marketing)
       .then((referral) => {
-        self._issueReferralSignupCredit(req.body, referral)
-          .then((credit) => self._convertReferralRecipient(referral, credit))
-          .then((referral) => res.status(200).send(referral))
-          .catch((err) => res.status(500).send(err));
+        Promise.join(
+          self._issueRegularSignupCredit(req.body),
+          self._issueReferralSignupCredit(req.body, referral),
+          function(regularCredit, referralCredit) {
+            self._convertReferralRecipient(referral, referralCredit)
+            .then((referral) => {
+            // TODO: Send details of credits created
+            // res.status(200).send({ referral, referralCredit, regularCredit })
+            // but format it pretty for user
+              res.status(200).send('Success');
+            })
+            .catch((err) => res.status(500).send(err));
+          }
+        )
       })
       .catch((err) => res.status(500).send(err))
   })
@@ -65,7 +80,9 @@ CreditsRouter.prototype.handleRegularSignup = function(req, res) {
   console.log('HIT: handleRegularSignup for', req.body);
   const self = this;
   self._issueRegularSignupCredit(req.body)
-    .then((credit) => res.status(200).send(credit))
+    // TODO: Send details of creidt created, formatted pretty for user
+    // res.status(200).send({ credit });
+    .then((credit) => res.status(200).send('Success'))
     .catch((err) => res.status(500).send(err));
 };
 


### PR DESCRIPTION
Removes giving out `new-signup` credit for users. This is now handled by `billing-importer` with `free_threshold` amount.

This PR cleans up all references to the `new-signup` credit, and adds documentation to methods related to signups.

Even though regular signups aren't issued a credit, a marketing doc is created on this route, which is why it is still used regardless of whether a credit is issued or not.